### PR TITLE
Add command support to pull request processing

### DIFF
--- a/__tests__/pullrequest.test.ts
+++ b/__tests__/pullrequest.test.ts
@@ -124,12 +124,12 @@ describe('Repository integration tests', () => {
   });
 
   test('A valid command is extracted', () => {
-    context.payload.pull_request.body += '\n /rm-ignore-length';
+    context.payload.pull_request.body += '\n /bot-ignore-length';
     expect(extractCommands(context.payload.pull_request.body).length).toBe(1);
   });
 
   test('Invalid commands are ignored', () => {
-    context.payload.pull_request.body += '\n /rm-ignore-length';
+    context.payload.pull_request.body += '\n /bot-ignore-length';
     context.payload.pull_request.body += '\n /rm-blarb';
 
     expect(extractCommands(context.payload.pull_request.body).length).toBe(1);
@@ -141,12 +141,12 @@ describe('Repository integration tests', () => {
   });
 
   test('The ignore command should be recognized', () => {
-    const commands = ['/rm-ignore-length'];
+    const commands = ['/bot-ignore-length'];
     expect(shouldIgnoredLengthCheck(commands)).toBeTruthy();
   });
 
   test('A PR with the ignore command should be ignored', async () => {
-    issueOpenedEvent.payload.pull_request.body += '\n /rm-ignore-length';
+    issueOpenedEvent.payload.pull_request.body += '\n /bot-ignore-length';
     await app.receive({
       name: 'pull_request.opened',
       payload: issueOpenedEvent.payload,

--- a/__tests__/pullrequest.test.ts
+++ b/__tests__/pullrequest.test.ts
@@ -22,28 +22,35 @@ import fs from 'fs';
 import path from 'path';
 import { Application, Context } from 'probot';
 import robot from '../src';
-import { fetchRepoMountieConfig, isValidPullRequestLength } from '../src/libs/pullrequest';
+import {
+  extractCommands,
+  fetchRepoMountieConfig,
+  isValidPullRequestLength,
+  shouldBeIgnored,
+} from '../src/libs/pullrequest';
 
 jest.mock('fs');
 
 const p0 = path.join(__dirname, 'fixtures/pull_request-opened-event.json');
-const issueOpenedEvent = JSON.parse(fs.readFileSync(p0, 'utf8'));
-
 const p1 = path.join(__dirname, 'fixtures/repo-get-content.json');
-const repoFileContent = JSON.parse(fs.readFileSync(p1, 'utf8'));
-
 const p2 = path.join(__dirname, 'fixtures/rmconfig.json');
-const repoMountieConfig = JSON.parse(fs.readFileSync(p2, 'utf8'));
 
 describe('Repository integration tests', () => {
   let app;
   let github;
   let context;
+  let issueOpenedEvent;
+  let repoFileContent;
+  let repoMountieConfig;
 
   beforeEach(() => {
     app = new Application();
     app.app = () => 'Token';
     app.load(robot);
+
+    issueOpenedEvent = JSON.parse(fs.readFileSync(p0, 'utf8'));
+    repoFileContent = JSON.parse(fs.readFileSync(p1, 'utf8'));
+    repoMountieConfig = JSON.parse(fs.readFileSync(p2, 'utf8'));
 
     github = {
       issues: {
@@ -110,6 +117,43 @@ describe('Repository integration tests', () => {
 
     expect(github.repos.getContents).toHaveBeenCalled();
     expect(github.issues.createComment).toHaveBeenCalled();
+  });
+
+  test('No commands are processed correctly', () => {
+    expect(extractCommands(context.payload.pull_request.body).length).toBe(0);
+  });
+
+  test('A valid command is extracted', () => {
+    context.payload.pull_request.body += '\n /rm-ignore';
+    expect(extractCommands(context.payload.pull_request.body).length).toBe(1);
+  });
+
+  test('Invalid commands are ignored', () => {
+    context.payload.pull_request.body += '\n /rm-ignore';
+    context.payload.pull_request.body += '\n /rm-blarb';
+
+    expect(extractCommands(context.payload.pull_request.body).length).toBe(1);
+  });
+
+  test('Empty commands should not be ignored', () => {
+    const commands = [];
+    expect(shouldBeIgnored(commands)).toBeFalsy();
+  });
+
+  test('The ignore command should be recognized', () => {
+    const commands = ['/rm-ignore'];
+    expect(shouldBeIgnored(commands)).toBeTruthy();
+  });
+
+  test('A PR with the ignore command should be ignored', async () => {
+    context.payload.pull_request.body += '\n /rm-ignore';
+    await app.receive({
+      name: 'pull_request.opened',
+      payload: issueOpenedEvent.payload,
+    });
+
+    expect(github.repos.getContents).not.toHaveBeenCalled();
+    expect(github.issues.createComment).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/pullrequest.test.ts
+++ b/__tests__/pullrequest.test.ts
@@ -26,7 +26,7 @@ import {
   extractCommands,
   fetchRepoMountieConfig,
   isValidPullRequestLength,
-  shouldBeIgnored,
+  shouldIgnoredLengthCheck,
 } from '../src/libs/pullrequest';
 
 jest.mock('fs');
@@ -124,12 +124,12 @@ describe('Repository integration tests', () => {
   });
 
   test('A valid command is extracted', () => {
-    context.payload.pull_request.body += '\n /rm-ignore';
+    context.payload.pull_request.body += '\n /rm-ignore-length';
     expect(extractCommands(context.payload.pull_request.body).length).toBe(1);
   });
 
   test('Invalid commands are ignored', () => {
-    context.payload.pull_request.body += '\n /rm-ignore';
+    context.payload.pull_request.body += '\n /rm-ignore-length';
     context.payload.pull_request.body += '\n /rm-blarb';
 
     expect(extractCommands(context.payload.pull_request.body).length).toBe(1);
@@ -137,22 +137,22 @@ describe('Repository integration tests', () => {
 
   test('Empty commands should not be ignored', () => {
     const commands = [];
-    expect(shouldBeIgnored(commands)).toBeFalsy();
+    expect(shouldIgnoredLengthCheck(commands)).toBeFalsy();
   });
 
   test('The ignore command should be recognized', () => {
-    const commands = ['/rm-ignore'];
-    expect(shouldBeIgnored(commands)).toBeTruthy();
+    const commands = ['/rm-ignore-length'];
+    expect(shouldIgnoredLengthCheck(commands)).toBeTruthy();
   });
 
   test('A PR with the ignore command should be ignored', async () => {
-    context.payload.pull_request.body += '\n /rm-ignore';
+    issueOpenedEvent.payload.pull_request.body += '\n /rm-ignore-length';
     await app.receive({
       name: 'pull_request.opened',
       payload: issueOpenedEvent.payload,
     });
 
-    expect(github.repos.getContents).not.toHaveBeenCalled();
+    expect(github.repos.getContents).toHaveBeenCalled();
     expect(github.issues.createComment).not.toHaveBeenCalled();
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,5 +55,5 @@ export const TEXT_FILES = {
 };
 
 export const COMMANDS = {
-  IGNORE: '/rm-ignore-length',
+  IGNORE: '/bot-ignore-length',
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,5 +55,5 @@ export const TEXT_FILES = {
 };
 
 export const COMMANDS = {
-  IGNORE: '/rm-ignore',
+  IGNORE: '/rm-ignore-length',
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,3 +53,7 @@ export const TEXT_FILES = {
   HOWTO_PR: 'templates/howto_pull_request.md',
   WHY_LICENSE: 'templates/why-license.md',
 };
+
+export const COMMANDS = {
+  IGNORE: '/rm-ignore',
+};

--- a/src/libs/pullrequest.ts
+++ b/src/libs/pullrequest.ts
@@ -20,7 +20,7 @@
 
 import { logger } from '@bcgov/nodejs-common-utils';
 import { Context } from 'probot';
-import { REPO_CONFIG_FILE, TEXT_FILES } from '../constants';
+import { COMMANDS, REPO_CONFIG_FILE, TEXT_FILES } from '../constants';
 import { loadTemplate } from '../libs/utils';
 
 interface RepoMountiePullRequestConfig {
@@ -57,6 +57,30 @@ export const fetchRepoMountieConfig = async (context: Context): Promise<RepoMoun
 };
 
 /**
+ * Check to see if a pull request (PR) contains the command for ignore.
+ *
+ * @param {string} body The body of the PR
+ * @returns True if the PR should be ignored, False otherwise
+ */
+export const shouldBeIgnored = (commands: string[]): boolean => {
+  if (commands.includes(COMMANDS.IGNORE)) {
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * Extract all commands from the body of a PR
+ *
+ * @param {string} body The body of the PR
+ * @returns An `string[]` any commands used
+ */
+export const extractCommands = (body: string): any[] => {
+  return Object.values(COMMANDS).filter(cmd => body.includes(cmd));
+};
+
+/**
  * Validate the length of a pull request
  * The length of a PR is determined by adding the lines deleted and added
  * @param {Context} context The event context context
@@ -80,6 +104,11 @@ export const isValidPullRequestLength = (context: Context, config: RepoMountieCo
  */
 export const validatePullRequestIfRequired = async (context: Context) => {
   try {
+    const commands = extractCommands(context.payload.pull_request.body);
+    if (shouldBeIgnored(commands)) {
+      return;
+    }
+
     const config = await fetchRepoMountieConfig(context);
 
     if (!isValidPullRequestLength(context, config)) {

--- a/templates/howto_pull_request.md
+++ b/templates/howto_pull_request.md
@@ -7,3 +7,7 @@ Here are a few thoughtful articles on what a good PR should look like:
 [Optimal Pull Request Size](https://smallbusinessprogramming.com/optimal-pull-request-size/)
 
 [Best Practices for Code Review](https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/)
+
+### Pro Tip
+
+- Add the command `/rm-ignore-length` in the body (preferably as the last line) of a PR if you have a legitimate reason for lengthy PR.

--- a/templates/howto_pull_request.md
+++ b/templates/howto_pull_request.md
@@ -10,4 +10,4 @@ Here are a few thoughtful articles on what a good PR should look like:
 
 ### Pro Tip
 
-- Add the command `/rm-ignore-length` in the body (preferably as the last line) of a PR if you have a legitimate reason for lengthy PR.
+- Add the command `/bot-ignore-length` in the body (preferably as the last line) of a PR if you have a legitimate reason for lengthy PR.

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,7 @@
     },
     "quotemark": [true, "single"],
     "interface-name": [true, "never-prefix"]
+    // "no-console": [false, "log", "error"]
   },
   "rulesDirectory": []
 }

--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,6 @@
     },
     "quotemark": [true, "single"],
     "interface-name": [true, "never-prefix"]
-    // "no-console": [false, "log", "error"]
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
There are some conditions when it's OK to ask the Repo Mountie to ignore pull request rules. This PR enables the PR creator to include a command to the Repo Mountie instructing it to bypass the PR length check.