### PR TITLE
Add health monitoring route

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,11 +25,14 @@ import { SCHEDULER_DELAY } from './constants';
 import { created } from './libs/issue';
 import { validatePullRequestIfRequired } from './libs/pullrequest';
 import { addLicenseIfRequired } from './libs/repository';
+import routes from './libs/routes';
 
 process.env.TZ = 'UTC';
 
 export = (app: Application) => {
   logger.info('Robot Loaded!!!');
+
+  routes(app);
 
   const scheduler = createScheduler(app, {
     delay: false, // !!process.env.DISABLE_DELAY, // delay is enabled on first run

--- a/src/libs/routes.ts
+++ b/src/libs/routes.ts
@@ -1,0 +1,31 @@
+//
+// Repo Mountie
+//
+// Copyright © 2018 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Created by Jason Leach on 2018-10-15.
+//
+
+import { Application } from 'probot';
+
+const routes = (app: Application) => {
+  // Get an express router to expose new HTTP endpoints
+  const router = app.route('/bot');
+
+  // Add a new route for health and liveliness probes.
+  router.get('/ehlo', (req: any, res: any) => res.status(200).end());
+};
+
+export default routes;


### PR DESCRIPTION
Added a route to the robot for the OpenShift readiness problem. This route just returns 200 OK when hit.