### PR TITLE
Fix the GitHub App ID check

### DIFF
--- a/.s2iignore
+++ b/.s2iignore
@@ -1,8 +1,9 @@
 __mocks__/
 __tests__/
-.git//
+.git/
 .github/
 .vscode/
+.gitignore
 .env.example
 .prettierrc
 *.md

--- a/src/config/development.json
+++ b/src/config/development.json
@@ -1,4 +1,5 @@
 {
+  "githubAppID": 19327,
   "sso": {
     "authUrl": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/auth",
     "tokenUrl": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/token",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -42,6 +42,7 @@ if (env === 'development') {
 // overrides are always as defined
 nconf.overrides({
   environment: env,
+  githubAppID: process.env.GITHUB_APP_ID,
   host: process.env.HOST || '127.0.0.1',
   port: process.env.PORT || defaultPort,
   sso: {

--- a/src/config/production.json
+++ b/src/config/production.json
@@ -1,4 +1,5 @@
 {
+  "githubAppID": 19327,
   "sso": {
     "authUrl": "https://sso.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/auth",
     "tokenUrl": "https://sso.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/token",

--- a/src/config/test.json
+++ b/src/config/test.json
@@ -1,4 +1,5 @@
 {
+  "githubAppID": 19327,
   "sso": {
     "authUrl": "https://sso-test.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/auth",
     "tokenUrl": "https://sso-test.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/token",

--- a/src/libs/routes.ts
+++ b/src/libs/routes.ts
@@ -22,6 +22,7 @@ import { logger } from '@bcgov/common-nodejs-utils';
 import express from 'express'; // tslint:disable-line
 import passport from 'passport';
 import { Application } from 'probot';
+import config from '../config';
 import { authmware } from './authmware';
 
 export const routes = (app: Application) => {
@@ -58,7 +59,7 @@ export const routes = (app: Application) => {
     '/github/membership',
     passport.authenticate('jwt', { session: false }),
     async (req: any, res: any) => {
-      const myAppId = 18286;
+      const myAppId = config.get('githubAppID');
       const myApp = req.app;
       const { userId } = req.query;
 


### PR DESCRIPTION
Parameterized the GitHub App ID for the Repo Mountie. It uses this check to make sure that requests come from the correct app.