### PR TITLE
Change response code when missing user ID

### DIFF
--- a/src/libs/routes.ts
+++ b/src/libs/routes.ts
@@ -64,7 +64,7 @@ export const routes = (app: Application) => {
 
       if (!userId) {
         // throw errorWithCode('You are not able to download this artifact', 400);
-        res.status(200).json({ message: 'You must supply a valid github user ID' });
+        res.status(400).json({ message: 'You must supply a valid github user ID' });
         return;
       }
 


### PR DESCRIPTION
Return code 400 when the userId parameter is missing.