### PR TITLE
Check if compliance file exists before creating the PR

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -23,7 +23,7 @@ import path from 'path';
 import { Application, Context } from 'probot';
 import robot from '../src';
 import { PR_TITLES, REPO_COMPLIANCE_FILE } from '../src/constants';
-import { addFileViaPullRequest, assignUsersToIssue, checkIfRefExists, extractMessage, fetchComplianceFile, fetchConfigFile, fetchContentsForFile, fetchFile, hasPullRequestWithTitle, labelExists, loadTemplate, updateFile } from '../src/libs/utils';
+import { addFileViaPullRequest, assignUsersToIssue, checkIfFileExists, checkIfRefExists, extractMessage, fetchComplianceFile, fetchConfigFile, fetchContentsForFile, fetchFile, hasPullRequestWithTitle, labelExists, loadTemplate, updateFile } from '../src/libs/utils';
 
 jest.mock('fs');
 
@@ -212,5 +212,17 @@ describe('Utility functions', () => {
     github.repos.createOrUpdateFile = jest.fn().mockReturnValueOnce(Promise.reject());
 
     await expect(updateFile(context, 'Hello', 'Hello', 'Hello.txt', 'data', '1bc3')).rejects.toThrow();
+  });
+
+  it('Return true if a file exists', async () => {
+    github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.resolve(complianceResponse));
+
+    await expect(checkIfFileExists(context, 'hello.yaml')).resolves.toBeTruthy();
+  });
+
+  it('Return false if a file does not exist', async () => {
+    github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.reject());
+
+    await expect(checkIfFileExists(context, 'hello.yaml')).resolves.toBeFalsy();
   });
 });

--- a/src/libs/repository.ts
+++ b/src/libs/repository.ts
@@ -22,7 +22,7 @@ import { logger } from '@bcgov/common-nodejs-utils';
 import { Context } from 'probot';
 import config from '../config';
 import { ACCESS_CONTROL, BRANCHES, COMMIT_FILE_NAMES, COMMIT_MESSAGES, PR_TITLES, TEMPLATES, TEXT_FILES } from '../constants';
-import { addFileViaPullRequest, checkIfRefExists, extractMessage, hasPullRequestWithTitle, loadTemplate } from './utils';
+import { addFileViaPullRequest, checkIfFileExists, checkIfRefExists, extractMessage, hasPullRequestWithTitle, loadTemplate } from './utils';
 
 export const addSecurityComplianceInfoIfRequired = async (context: Context, scheduler: any = undefined) => {
 
@@ -40,6 +40,11 @@ export const addSecurityComplianceInfoIfRequired = async (context: Context, sche
 
     if ((await hasPullRequestWithTitle(context, PR_TITLES.ADD_COMPLIANCE, 'open'))) {
       logger.info(`Compliance PR exists in ${context.payload.repository.name}`);
+      return;
+    }
+
+    if ((await checkIfFileExists(context, COMMIT_FILE_NAMES.COMPLIANCE))) {
+      logger.info(`Compliance file exists in ${context.payload.repository.name}`);
       return;
     }
 

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -79,6 +79,15 @@ export const checkIfRefExists = async (context: Context, ref = 'master'): Promis
   }
 };
 
+export const checkIfFileExists = async (context, fileName, ref = 'master'): Promise<boolean> => {
+  try {
+    await fetchFile(context, fileName, ref);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};
+
 export const fetchContentsForFile = async (context, fileName, ref = 'master'): Promise<any> => {
   const commits = await context.github.repos.listCommits(
     context.repo({


### PR DESCRIPTION
Some repos may have a compliance file already if they were cloned or created from a template. In this case we don't want to create a PR to add an additional compliance file.

Fixes #35 