### PR TITLE
Fix issue causing comments to be skipped

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -76,6 +76,10 @@ export const COMMANDS = {
   IGNORE: '/bot-ignore-length',
 };
 
+export const REGEXP = {
+  compliance: '/update-(pia|stra)\\s(in-progress|completed|TBD|exempt)'
+}
+
 export const ACCESS_CONTROL = {
   allowedInstallations: ['bcgov', 'fullboar'],
   allowedSsoClients: ['reggie-api'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,6 @@ import { fetchConfigFile } from './libs/utils';
 
 process.env.TZ = 'UTC';
 
-console.log('hello world');
-
 if (['development', 'test'].includes(process.env.NODE_ENV || 'development')) {
   process.on('unhandledRejection', (reason, p) => {
     // @ts-ignore: `stack` does not exist on type
@@ -97,7 +95,7 @@ export = (app: Application) => {
 
   async function issueCommentCreated(context: Context) {
     try {
-      const owner = context.payload.installation.account.login;
+      const owner = context.payload.organization.login;
       const isFromBot = context.isBot;
 
       if (!ACCESS_CONTROL.allowedInstallations.includes(owner)) {

--- a/src/libs/robo.ts
+++ b/src/libs/robo.ts
@@ -21,7 +21,7 @@
 import { logger } from '@bcgov/common-nodejs-utils';
 import yaml from 'js-yaml';
 import { Context } from 'probot';
-import { BRANCHES, COMMENT_TRIGGER_WORD, COMMIT_FILE_NAMES, COMMIT_MESSAGES, GITHUB_ID, HELP_DESK, PR_TITLES } from '../constants';
+import { BRANCHES, COMMENT_TRIGGER_WORD, COMMIT_FILE_NAMES, COMMIT_MESSAGES, HELP_DESK, PR_TITLES } from '../constants';
 import { assignUsersToIssue, fetchContentsForFile, updateFileContent } from './utils';
 
 const re = /\/update-(pia|stra)\s(in-progress|completed|TBD|exempt)/gi;
@@ -49,6 +49,7 @@ export const helpDeskSupportRequired = (payload: any) => {
 
 export const applyComplianceCommands = (comment: string, doc: any): any => {
     let result: RegExpExecArray | null;
+    re.lastIndex = 0; // reset
 
     while ((result = re.exec(comment)) !== null) {
         // sample result 
@@ -111,7 +112,8 @@ export const handleComplianceCommands = async (context: Context) => {
 };
 
 export const handleBotCommand = async (context: Context) => {
-    if (context.payload.issue.user.login === `${GITHUB_ID}[bot]`) {
+
+    if (context.isBot) {
         return; // not interested
     }
 

--- a/src/libs/robo.ts
+++ b/src/libs/robo.ts
@@ -21,10 +21,8 @@
 import { logger } from '@bcgov/common-nodejs-utils';
 import yaml from 'js-yaml';
 import { Context } from 'probot';
-import { BRANCHES, COMMENT_TRIGGER_WORD, COMMIT_FILE_NAMES, COMMIT_MESSAGES, HELP_DESK, PR_TITLES } from '../constants';
+import { BRANCHES, COMMENT_TRIGGER_WORD, COMMIT_FILE_NAMES, COMMIT_MESSAGES, HELP_DESK, PR_TITLES, REGEXP } from '../constants';
 import { assignUsersToIssue, fetchContentsForFile, updateFileContent } from './utils';
-
-const re = /\/update-(pia|stra)\s(in-progress|completed|TBD|exempt)/gi;
 
 /**
  * Determine if help desk support is required
@@ -49,7 +47,7 @@ export const helpDeskSupportRequired = (payload: any) => {
 
 export const applyComplianceCommands = (comment: string, doc: any): any => {
     let result: RegExpExecArray | null;
-    re.lastIndex = 0; // reset
+    const re = new RegExp(REGEXP.compliance, 'gi');
 
     while ((result = re.exec(comment)) !== null) {
         // sample result 
@@ -80,8 +78,8 @@ export const handleComplianceCommands = async (context: Context) => {
     // /update-stra ${STATUS}
 
     const comment = context.payload.comment.body;
+    const re = new RegExp(REGEXP.compliance, 'gi');
 
-    re.lastIndex = 0; // reset
     if (!re.test(comment)) {
         return; // no commands in comment
     }

--- a/src/libs/robo.ts
+++ b/src/libs/robo.ts
@@ -81,6 +81,7 @@ export const handleComplianceCommands = async (context: Context) => {
 
     const comment = context.payload.comment.body;
 
+    re.lastIndex = 0; // reset
     if (!re.test(comment)) {
         return; // no commands in comment
     }


### PR DESCRIPTION
Fixed two issues:

- The bot was not properly extracting the org owner and thus failing to process issue comments;
- The RegEx used to check for commands is statefull and needed to be reset.

Fixed #37 