### PR TITLE
Use repos default branch rather than master

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -142,7 +142,7 @@ describe('Utility functions', () => {
 
   it('The ref should exists.', async () => {
     github.git.getRef.mockReturnValueOnce(master);
-    const result = await checkIfRefExists(context, 'master');
+    const result = await checkIfRefExists(context, context.payload.repository.default_branch);
 
     expect(github.git.getRef).toHaveBeenCalled();
     expect(result).toBeTruthy();
@@ -150,7 +150,7 @@ describe('Utility functions', () => {
 
   it('The ref should not exists.', async () => {
     github.git.getRef.mockReturnValueOnce(Promise.reject());
-    const result = await checkIfRefExists(context, 'master');
+    const result = await checkIfRefExists(context, context.payload.repository.default_branch);
 
     expect(github.git.getRef).toHaveBeenCalled();
     expect(result).toBeFalsy();

--- a/src/libs/repository.ts
+++ b/src/libs/repository.ts
@@ -33,8 +33,8 @@ export const addSecurityComplianceInfoIfRequired = async (context: Context, sche
   }
 
   try {
-    if (!(await checkIfRefExists(context, 'master'))) {
-      logger.info(`This repo has no master branch ${context.payload.repository.name}`);
+    if (!(await checkIfRefExists(context, context.payload.repository.default_branch))) {
+      logger.info(`This repo has no main branch ${context.payload.repository.name}`);
       return;
     }
 
@@ -70,8 +70,8 @@ export const addLicenseIfRequired = async (context: Context, scheduler: any = un
   }
 
   try {
-    if (!(await checkIfRefExists(context, 'master'))) {
-      logger.info(`This repo has no master branch ${context.payload.repository.name}`);
+    if (!(await checkIfRefExists(context, context.payload.repository.default_branch))) {
+      logger.info(`This repo has no main branch ${context.payload.repository.name}`);
       return;
     }
 


### PR DESCRIPTION
The bot assumes master is the default branch that should be the root of all other branches. This does not always work as repos can specify what branch is `master` to them. This PR update the bot to use the `default_branch` as the root of any new branches.

Fixes #39 