### PR TITLE
Add org owner check to cmd handling

### DIFF
--- a/__tests__/fixtures/org-user-ismember.json
+++ b/__tests__/fixtures/org-user-ismember.json
@@ -1,0 +1,23 @@
+{
+  "status": 204,
+  "url": "https://api.github.com/organizations/762183/public_members/jleach",
+  "headers": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
+    "connection": "close",
+    "content-security-policy": "default-src 'none'",
+    "date": "Wed, 18 Dec 2019 19:54:12 GMT",
+    "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+    "server": "GitHub.com",
+    "status": "204 No Content",
+    "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "deny",
+    "x-github-media-type": "github.v3; format=json",
+    "x-github-request-id": "CEA6:27B5:3AA93B:786C1A:5DFA83E4",
+    "x-ratelimit-limit": "5000",
+    "x-ratelimit-remaining": "4666",
+    "x-ratelimit-reset": "1576700113",
+    "x-xss-protection": "1; mode=block"
+  }
+}

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -23,7 +23,7 @@ import path from 'path';
 import { Application, Context } from 'probot';
 import robot from '../src';
 import { PR_TITLES, REPO_COMPLIANCE_FILE } from '../src/constants';
-import { addFileViaPullRequest, assignUsersToIssue, checkIfRefExists, extractMessage, fetchComplianceFile, fetchConfigFile, fetchContentsForFile, fetchFile, hasPullRequestWithTitle, isMember, labelExists, loadTemplate, updateFileContent } from '../src/libs/utils';
+import { addFileViaPullRequest, assignUsersToIssue, checkIfRefExists, extractMessage, fetchComplianceFile, fetchConfigFile, fetchContentsForFile, fetchFile, hasPullRequestWithTitle, isOrgMember, labelExists, loadTemplate, updateFileContent } from '../src/libs/utils';
 
 jest.mock('fs');
 
@@ -227,7 +227,7 @@ describe('Utility functions', () => {
   it('A user is a member of the organization', async () => {
     github.orgs.checkMembership = jest.fn().mockReturnValueOnce(Promise.resolve(memberhip));
 
-    const result = await isMember(context, 'helloworld');
+    const result = await isOrgMember(context, 'helloworld');
     expect(result).toBeTruthy();
   });
 
@@ -237,7 +237,7 @@ describe('Utility functions', () => {
 
     github.orgs.checkMembership = jest.fn().mockReturnValueOnce(Promise.reject(err));
 
-    const result = await isMember(context, 'helloworld');
+    const result = await isOrgMember(context, 'helloworld');
     expect(result).toBeFalsy();
   });
 
@@ -246,14 +246,14 @@ describe('Utility functions', () => {
 
     github.orgs.checkMembership = jest.fn().mockReturnValueOnce(Promise.reject(err));
 
-    await expect(isMember(context, 'helloworld')).rejects.toThrow();
+    await expect(isOrgMember(context, 'helloworld')).rejects.toThrow();
   });
 
   it('A user lookup fails due to an unexpected http code', async () => {
     memberhip.status = 512;
     github.orgs.checkMembership = jest.fn().mockReturnValueOnce(Promise.resolve(memberhip));
 
-    const result = await isMember(context, 'helloworld');
+    const result = await isOrgMember(context, 'helloworld');
     expect(result).toBeFalsy();
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-mountie",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A bot to help ensure cultural niceties are respected.",
   "author": "Jason C. Leach <jason.leach@fullboar.ca>",
   "license": "Apache-2.0",

--- a/src/libs/issue.ts
+++ b/src/libs/issue.ts
@@ -73,7 +73,7 @@ export const checkForStaleIssues = async (context: Context, config: RepoMountieC
     const body = rawMessageBody
       .replace(regex, `${config.staleIssue.maxDaysOld}`);
 
-    let labels: Array<string> = [];
+    const labels: string[] = [];
     if (config.staleIssue && config.staleIssue.applyLabel && (await labelExists(context, config.staleIssue.applyLabel))) {
       labels.push(config.staleIssue.applyLabel)
     }

--- a/src/libs/issue.ts
+++ b/src/libs/issue.ts
@@ -22,7 +22,7 @@ import { logger } from '@bcgov/common-nodejs-utils';
 import { flatten } from 'lodash';
 import { Context } from 'probot';
 import { TEXT_FILES } from '../constants';
-import { isMember, labelExists, loadTemplate, RepoMountieConfig } from '../libs/utils';
+import { isOrgMember, labelExists, loadTemplate, RepoMountieConfig } from '../libs/utils';
 import { handleBotCommand } from './robo';
 
 /**
@@ -34,7 +34,7 @@ import { handleBotCommand } from './robo';
  */
 export const created = async (context: Context) => {
 
-  if (!(await isMember(context, context.payload.comment.user.login))) {
+  if (!(await isOrgMember(context, context.payload.comment.user.login))) {
     return;
   }
 

--- a/src/libs/issue.ts
+++ b/src/libs/issue.ts
@@ -22,7 +22,7 @@ import { logger } from '@bcgov/common-nodejs-utils';
 import { flatten } from 'lodash';
 import { Context } from 'probot';
 import { TEXT_FILES } from '../constants';
-import { labelExists, loadTemplate, RepoMountieConfig } from '../libs/utils';
+import { isMember, labelExists, loadTemplate, RepoMountieConfig } from '../libs/utils';
 import { handleBotCommand } from './robo';
 
 /**
@@ -33,6 +33,10 @@ import { handleBotCommand } from './robo';
  * @returns No return value
  */
 export const created = async (context: Context) => {
+
+  if (!(await isMember(context, context.payload.comment.user.login))) {
+    return;
+  }
 
   // check for and handle bot commands
   await handleBotCommand(context);

--- a/src/libs/robo.ts
+++ b/src/libs/robo.ts
@@ -63,7 +63,7 @@ export const applyComplianceCommands = (comment: string, doc: any): any => {
         }
 
         const item = items.pop();
-        item['status'] = result![2];
+        item.status = result![2];
         // Date.now() used to simplify mock in unit tests.
         item['last-updated'] = new Date(Date.now()).toISOString();
     }

--- a/src/libs/robo.ts
+++ b/src/libs/robo.ts
@@ -117,7 +117,7 @@ export const handleBotCommand = async (context: Context) => {
     }
 
     try {
-        // For we just assign help desk willynilly, going forward we should
+        // For we just assign help desk willy-nilly, going forward we should
         // better identify the issue and assign users with surgical precision.
         if (helpDeskSupportRequired(context.payload)) {
             await assignUsersToIssue(context, HELP_DESK.SUPPORT_USERS)

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -414,3 +414,33 @@ export const updateFileContent = async (
     throw err;
   }
 };
+
+export const isMember = async (context: Context, userID: string): Promise<boolean> => {
+  try {
+    const response = await context.github.orgs.checkMembership({
+      org: context.payload.organization.login,
+      username: userID
+    });
+
+    if (response.status === 204 || response.status === 302) {
+      // 204 No Content - The user is a member;
+      // 302 Found      - TBD
+      return true;
+    }
+
+    const message = 'Unexpected return code looking up user';
+    logger.info(`${message}, code = ${response.status}`);
+
+    return false;
+  } catch (err) {
+    // 404 Not Found  - The user is not a member of the org.
+    if (err.code === 404) {
+      return false;
+    }
+
+    const message = 'Unable to lookup user';
+    logger.error(`${message}, error = ${err.message}`);
+
+    throw err;
+  }
+}

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -354,7 +354,7 @@ export const hasPullRequestWithTitle = async (
   try {
     const pulls = await context.github.pulls.list(
       context.repo({
-        state: state,
+        state,
       })
     );
 
@@ -377,7 +377,7 @@ export const hasPullRequestWithTitle = async (
  * @param assignees An `Array` of users to assign to the issue
  */
 export const assignUsersToIssue = async (
-  context: Context, assignees: Array<string>
+  context: Context, assignees: string[]
 ) => {
   try {
     await context.github.issues.addAssignees(

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -415,7 +415,7 @@ export const updateFileContent = async (
   }
 };
 
-export const isMember = async (context: Context, userID: string): Promise<boolean> => {
+export const isOrgMember = async (context: Context, userID: string): Promise<boolean> => {
   try {
     const response = await context.github.orgs.checkMembership({
       org: context.payload.organization.login,

--- a/templates/why-comply.md
+++ b/templates/why-comply.md
@@ -1,10 +1,10 @@
 ## TL;DR 🏎️
 
-Your repo is missing a compliance audit file so I've created this PR with a **template** that you can update with the correct PIA and STRA status (status options in the table below). If you'd like me to do this for you skip to the _commands_ below.
+Your repo is missing a compliance audit file so I've created this PR with a **template** that you can update with the correct PIA and STRA status (status options in the table below). If you'd like me to do this for you, skip to the _commands_ section below.
 
 ## Compliance
 
-Projects in our organization (bcgov) need to complete a Privacy Assessment (PIA) and Security Threat & Risk Assessment (STRA) before they go live in production. Since every ministry has their own way of doing both the STRA and PIA we don't enforce that projects do them, only that they report on the current status.
+Projects in our organization (bcgov) need to complete a Privacy Impact Assessment (PIA) and Security Threat & Risk Assessment (STRA) before they go live in production. Since every ministry has their own way of doing both the STRA and PIA we don't enforce that projects do them, only that they report on the current status.
 
 To help with reporting, I've added a compliance audit file as part of this pull request. Please checkout this branch and edit update `status` as needed. Here is a table of possible states:
 
@@ -35,11 +35,11 @@ For more information check out the [BC Policy Framework for GitHub][1].
 
 ### Pro Tip 🤓
 
-- If you're not sure what to do **add a comment below** with the word **help** in it; a real-live-person will reply back to help you out.
+- If you're not sure what to do **add a comment below** with the command **/help** in it; a real-live-person will reply back to help you out.
 
 ### Commands 🤖
 
-I can update the status of the PIA and STRA for you; you'll just need to merge the PR when I'm done. You can find the available STATUS values in the table above. Below are some commands I understand:
+I can update the status of the PIA and STRA for you; **you'll** just need to merge the PR when I'm done. You can find the available `status` values in the table above. Below are some commands I understand:
 
 | Command             | Description                                       |
 | :------------------ | :------------------------------------------------ |


### PR DESCRIPTION
Before handling any user provided commands the bot first makes sure said user is part of the organization. This will prevent abuse of the bot by mischief makers.

Fixes #45 