### PR TITLE
Change bot command structure

### DIFF
--- a/__tests__/robo.test.ts
+++ b/__tests__/robo.test.ts
@@ -66,7 +66,7 @@ describe('Bot command processing', () => {
     });
 
     it('Valid compliance commands are processed', async () => {
-        const comment = '/update-pia completed\n/update-stra completed';
+        const comment = '@rm update-pia completed\n@rm update-stra completed';
         const result = applyComplianceCommands(comment, doc);
         expect(result).toMatchSnapshot();
     });
@@ -85,7 +85,7 @@ describe('Bot command processing', () => {
     });
 
     it('Missing file causes update to be skipped', async () => {
-        context.payload.comment.body = '/update-pia completed';
+        context.payload.comment.body = '@rm update-pia completed';
         // @ts-ignore
         fetchContentsForFile.mockReturnValueOnce(undefined);
 
@@ -97,7 +97,7 @@ describe('Bot command processing', () => {
 
 
     it('Invalid command causes update to be skipped', async () => {
-        context.payload.comment.body = '/update-blarb completed';
+        context.payload.comment.body = '@rm update-blarb completed';
         // @ts-ignore
         fetchContentsForFile.mockReturnValueOnce(content.data);
 
@@ -108,7 +108,7 @@ describe('Bot command processing', () => {
     });
 
     it('Compliance commands are processed appropriately', async () => {
-        context.payload.comment.body = '/update-pia completed';
+        context.payload.comment.body = '@rm update-pia completed';
         // @ts-ignore
         fetchContentsForFile.mockReturnValueOnce(content.data);
 
@@ -119,7 +119,7 @@ describe('Bot command processing', () => {
     });
 
     it('An error is handled correctly', async () => {
-        context.payload.comment.body = '/help';
+        context.payload.comment.body = '@rm help';
         context.payload.issue.title = PR_TITLES.ADD_COMPLIANCE;
         // @ts-ignore
         assignUsersToIssue.mockRejectedValueOnce(new Error());

--- a/__tests__/robo.test.ts
+++ b/__tests__/robo.test.ts
@@ -66,7 +66,7 @@ describe('Bot command processing', () => {
     });
 
     it('Valid compliance commands are processed', async () => {
-        const comment = '@rm update-pia completed\n@rm update-stra completed';
+        const comment = `@repo-mountie update-pia completed\n@repo-mountie update-stra completed`;
         const result = applyComplianceCommands(comment, doc);
         expect(result).toMatchSnapshot();
     });
@@ -85,7 +85,7 @@ describe('Bot command processing', () => {
     });
 
     it('Missing file causes update to be skipped', async () => {
-        context.payload.comment.body = '@rm update-pia completed';
+        context.payload.comment.body = `@repo-mountie update-pia completed`;
         // @ts-ignore
         fetchContentsForFile.mockReturnValueOnce(undefined);
 
@@ -97,7 +97,7 @@ describe('Bot command processing', () => {
 
 
     it('Invalid command causes update to be skipped', async () => {
-        context.payload.comment.body = '@rm update-blarb completed';
+        context.payload.comment.body = `@repo-mountie update-blarb completed`;
         // @ts-ignore
         fetchContentsForFile.mockReturnValueOnce(content.data);
 
@@ -108,7 +108,7 @@ describe('Bot command processing', () => {
     });
 
     it('Compliance commands are processed appropriately', async () => {
-        context.payload.comment.body = '@rm update-pia completed';
+        context.payload.comment.body = `@repo-mountie update-pia completed`;
         // @ts-ignore
         fetchContentsForFile.mockReturnValueOnce(content.data);
 
@@ -119,7 +119,7 @@ describe('Bot command processing', () => {
     });
 
     it('An error is handled correctly', async () => {
-        context.payload.comment.body = '@rm help';
+        context.payload.comment.body = `@repo-mountie help`;
         context.payload.issue.title = PR_TITLES.ADD_COMPLIANCE;
         // @ts-ignore
         assignUsersToIssue.mockRejectedValueOnce(new Error());

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,7 +77,8 @@ export const COMMANDS = {
 };
 
 export const REGEXP = {
-  compliance: '/update-(pia|stra)\\s(in-progress|completed|TBD|exempt)'
+  command: '@rm\\s+',
+  compliance: '@rm\\s+update-(pia|stra)\\s+(in-progress|completed|TBD|exempt)'
 }
 
 export const ACCESS_CONTROL = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,8 +77,8 @@ export const COMMANDS = {
 };
 
 export const REGEXP = {
-  command: '@rm\\s+',
-  compliance: '@rm\\s+update-(pia|stra)\\s+(in-progress|completed|TBD|exempt)'
+  command: '@repo-mountie\\s+',
+  compliance: '@repo-mountie\\s+update-(pia|stra)\\s+(in-progress|completed|TBD|exempt)',
 }
 
 export const ACCESS_CONTROL = {

--- a/src/libs/issue.ts
+++ b/src/libs/issue.ts
@@ -21,7 +21,7 @@
 import { logger } from '@bcgov/common-nodejs-utils';
 import { flatten } from 'lodash';
 import { Context } from 'probot';
-import { TEXT_FILES } from '../constants';
+import { REGEXP, TEXT_FILES } from '../constants';
 import { isOrgMember, labelExists, loadTemplate, RepoMountieConfig } from '../libs/utils';
 import { handleBotCommand } from './robo';
 
@@ -33,13 +33,18 @@ import { handleBotCommand } from './robo';
  * @returns No return value
  */
 export const created = async (context: Context) => {
+  const re = new RegExp(REGEXP.command, 'gi');
+
+  // TODO:(jl) Need to wrap in try/catch.
 
   if (!(await isOrgMember(context, context.payload.comment.user.login))) {
     return;
   }
 
   // check for and handle bot commands
-  await handleBotCommand(context);
+  if (re.test(context.payload.comment.body)) {
+    await handleBotCommand(context);
+  }
 };
 
 export const checkForStaleIssues = async (context: Context, config: RepoMountieConfig) => {

--- a/src/libs/robo.ts
+++ b/src/libs/robo.ts
@@ -73,8 +73,8 @@ export const applyComplianceCommands = (comment: string, doc: any): any => {
 export const handleComplianceCommands = async (context: Context) => {
     // These are the accepted commands. They are case insensitive,
     // and require a leading `@re` to be accepted.
-    // @rm update-pia STATUS
-    // @rm update-stra STATUS
+    // @${WHOAMI} update-pia STATUS
+    // @${WHOAMI} update-stra STATUS
     const re = new RegExp(REGEXP.compliance, 'gi');
     const comment = context.payload.comment.body;
 

--- a/src/libs/robo.ts
+++ b/src/libs/robo.ts
@@ -44,7 +44,6 @@ export const helpDeskSupportRequired = (payload: any) => {
     return true;
 };
 
-
 export const applyComplianceCommands = (comment: string, doc: any): any => {
     let result: RegExpExecArray | null;
     const re = new RegExp(REGEXP.compliance, 'gi');
@@ -73,18 +72,18 @@ export const applyComplianceCommands = (comment: string, doc: any): any => {
 
 export const handleComplianceCommands = async (context: Context) => {
     // These are the accepted commands. They are case insensitive,
-    // and require a leading `/` to be accepted.
-    // /update-pia ${STATUS}
-    // /update-stra ${STATUS}
-
-    const comment = context.payload.comment.body;
+    // and require a leading `@re` to be accepted.
+    // @rm update-pia STATUS
+    // @rm update-stra STATUS
     const re = new RegExp(REGEXP.compliance, 'gi');
-
-    if (!re.test(comment)) {
-        return; // no commands in comment
-    }
+    const comment = context.payload.comment.body;
 
     try {
+        // check for appropriate bot commands
+        if (!re.test(comment)) {
+            return;
+        }
+
         // Fetch the file from the repo in case any updates have
         // been made to it.
         const data = await fetchContentsForFile(context,

--- a/templates/why-comply.md
+++ b/templates/why-comply.md
@@ -41,17 +41,17 @@ For more information check out the [BC Policy Framework for GitHub][1].
 
 I can update the status of the PIA and STRA for you; **you'll** just need to merge the PR when I'm done. You can find the available `status` values in the table above. Below are some commands I understand:
 
-| Command             | Description                                       |
-| :------------------ | :------------------------------------------------ |
-| /help               | You're freaking out and want to talk to a person. |
-| /update-pia STATUS  | You want me to update the PIA status.             |
-| /update-stra STATUS | You want me to update the STRA status.            |
+| Command                | Description                                       |
+| :--------------------- | :------------------------------------------------ |
+| @rm help               | You're freaking out and want to talk to a person. |
+| @rm update-pia STATUS  | You want me to update the PIA status.             |
+| @rm update-stra STATUS | You want me to update the STRA status.            |
 
 #### Examples
 
 ```console
-/update-pia completed
-/update-stra in-progress
+@rm update-pia completed
+@rm update-stra in-progress
 ```
 
 [1]: https://github.com/bcgov/BC-Policy-Framework-For-GitHub/tree/master/BC-Open-Source-Development-Employee-Guide

--- a/templates/why-comply.md
+++ b/templates/why-comply.md
@@ -41,17 +41,17 @@ For more information check out the [BC Policy Framework for GitHub][1].
 
 I can update the status of the PIA and STRA for you; **you'll** just need to merge the PR when I'm done. You can find the available `status` values in the table above. Below are some commands I understand:
 
-| Command                | Description                                       |
-| :--------------------- | :------------------------------------------------ |
-| @rm help               | You're freaking out and want to talk to a person. |
-| @rm update-pia STATUS  | You want me to update the PIA status.             |
-| @rm update-stra STATUS | You want me to update the STRA status.            |
+| Command                          | Description                                       |
+| :------------------------------- | :------------------------------------------------ |
+| @repo-mountie help               | You're freaking out and want to talk to a person. |
+| @repo-mountie update-pia STATUS  | You want me to update the PIA status.             |
+| @repo-mountie update-stra STATUS | You want me to update the STRA status.            |
 
 #### Examples
 
 ```console
-@rm update-pia completed
-@rm update-stra in-progress
+@repo-mountie update-pia completed
+@repo-mountie update-stra in-progress
 ```
 
 [1]: https://github.com/bcgov/BC-Policy-Framework-For-GitHub/tree/master/BC-Open-Source-Development-Employee-Guide

--- a/templates/why-license.md
+++ b/templates/why-license.md
@@ -8,10 +8,24 @@ For more information, or for out-of-the-box situations check out the [BC Policy 
 
 Since most repos are code based I've added the Apache-2.0 license as part of this PR. Please checkout this branch and change the license as needed or merge if if you're happy with my suggestion.
 
-### Pro Tip
+### Pro Tip 🤓
 
-- If you're not sure what to do **add a comment below** with the word **help** in it; a real-live-person will reply back to help you out.
+- If you're not sure what to do **add a comment** with the the command **@rm help** in it; a real-live-person will reply back to help you out.
 
 - Only license content BCGov creates. If it was created by someone else **you must** include the original license that work was released under.
+
+### Commands 🤖
+
+I can update the status of the PIA and STRA for you; **you'll** just need to merge the PR when I'm done. You can find the available `status` values in the table above. Below are some commands I understand:
+
+| Command  | Description                                       |
+| :------- | :------------------------------------------------ |
+| @rm help | You're freaking out and want to talk to a person. |
+
+#### Examples
+
+```console
+@rm help
+```
 
 [1]: https://github.com/bcgov/BC-Policy-Framework-For-GitHub/tree/master/BC-Open-Source-Development-Employee-Guide

--- a/templates/why-license.md
+++ b/templates/why-license.md
@@ -10,7 +10,7 @@ Since most repos are code based I've added the Apache-2.0 license as part of thi
 
 ### Pro Tip 🤓
 
-- If you're not sure what to do **add a comment** with the the command **@rm help** in it; a real-live-person will reply back to help you out.
+- If you're not sure what to do **add a comment** with the the command **@repo-mountie help** in it; a real-live-person will reply back to help you out.
 
 - Only license content BCGov creates. If it was created by someone else **you must** include the original license that work was released under.
 
@@ -18,14 +18,14 @@ Since most repos are code based I've added the Apache-2.0 license as part of thi
 
 I can update the status of the PIA and STRA for you; **you'll** just need to merge the PR when I'm done. You can find the available `status` values in the table above. Below are some commands I understand:
 
-| Command  | Description                                       |
-| :------- | :------------------------------------------------ |
-| @rm help | You're freaking out and want to talk to a person. |
+| Command            | Description                                       |
+| :----------------- | :------------------------------------------------ |
+| @repo-mountie help | You're freaking out and want to talk to a person. |
 
 #### Examples
 
 ```console
-@rm help
+@repo-mountie help
 ```
 
 [1]: https://github.com/bcgov/BC-Policy-Framework-For-GitHub/tree/master/BC-Open-Source-Development-Employee-Guide


### PR DESCRIPTION
Changed the bot command structure from requiring the `/` prefix to requiring `@rm` to be the prefix. This brings it in line with GitHub's dependabot.

Changed from:
```console
/help
```

to

```console
@repo-mountie help
```
