### PR TITLE
Check if a compliance file exists befor creating a PR

### DIFF
--- a/__tests__/repository.test.ts
+++ b/__tests__/repository.test.ts
@@ -36,6 +36,7 @@ jest.mock('../src/libs/utils', () => ({
     addFileViaPullRequest: jest.fn(),
     extractMessage: jest.fn().mockReturnValue('Hello Message'),
     loadTemplate: jest.fn().mockReturnValue('Hello'),
+    fileExists: jest.fn().mockReturnValue(false),
 }));
 
 describe('Repository integration tests', () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -22,7 +22,7 @@ import fs from 'fs';
 import path from 'path';
 import { Application, Context } from 'probot';
 import robot from '../src';
-import { PR_TITLES, REPO_COMPLIANCE_FILE } from '../src/constants';
+import { FILE_NAMES, PR_TITLES } from '../src/constants';
 import { addCommentToIssue, addFileViaPullRequest, assignUsersToIssue, checkIfRefExists, extractMessage, fetchComplianceFile, fetchConfigFile, fetchContentsForFile, fetchFile, hasPullRequestWithTitle, isOrgMember, labelExists, loadTemplate, updateFileContent } from '../src/libs/utils';
 
 jest.mock('fs');
@@ -126,7 +126,7 @@ describe('Utility functions', () => {
 
   it('A file should be retrieved.', async () => {
     github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.resolve(complianceResponse));
-    const data = await fetchFile(context, REPO_COMPLIANCE_FILE);
+    const data = await fetchFile(context, FILE_NAMES.COMPLIANCE);
 
     expect(data).toMatchSnapshot();
   });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -23,7 +23,7 @@ import path from 'path';
 import { Application, Context } from 'probot';
 import robot from '../src';
 import { FILE_NAMES, PR_TITLES } from '../src/constants';
-import { addCommentToIssue, addFileViaPullRequest, assignUsersToIssue, checkIfRefExists, extractMessage, fetchComplianceFile, fetchConfigFile, fetchContentsForFile, fetchFile, hasPullRequestWithTitle, isOrgMember, labelExists, loadTemplate, updateFileContent } from '../src/libs/utils';
+import { addCommentToIssue, addFileViaPullRequest, assignUsersToIssue, checkIfRefExists, extractMessage, fetchComplianceFile, fetchConfigFile, fetchContentsForFile, fetchFile, fileExists, hasPullRequestWithTitle, isOrgMember, labelExists, loadTemplate, updateFileContent } from '../src/libs/utils';
 
 jest.mock('fs');
 
@@ -268,5 +268,21 @@ describe('Utility functions', () => {
     github.issues.createComment = jest.fn().mockReturnValueOnce(Promise.reject(new Error()));
 
     await expect(addCommentToIssue(context, 'helloworld')).rejects.toThrow();
+  });
+
+  it('A file should be determined to exists', async () => {
+    github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.resolve(complianceResponse));
+    const results = await fileExists(context, FILE_NAMES.COMPLIANCE);
+
+    expect(github.repos.getContents).toHaveBeenCalled();
+    expect(results).toBeTruthy();
+  });
+
+  it('A file should be determined to not exists', async () => {
+    github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.reject());
+    const results = await fileExists(context, FILE_NAMES.COMPLIANCE);
+
+    expect(github.repos.getContents).toHaveBeenCalled();
+    expect(results).toBeFalsy();
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,17 +24,14 @@ export const COMMENT_TRIGGER_WORD = 'help';
 
 export const GITHUB_ID = 'repo-mountie';
 
-export const REPO_CONFIG_FILE = 'rmconfig.json';
-
-export const REPO_COMPLIANCE_FILE = 'compliance.yaml';
-
 export const HELP_DESK = {
   SUPPORT_USERS: ['jleach'],
 };
 
-export const COMMIT_FILE_NAMES = {
+export const FILE_NAMES = {
   LICENSE: 'LICENSE',
   COMPLIANCE: 'COMPLIANCE.yaml',
+  CONFIG: 'rmconfig.json'
 }
 
 export const COMMIT_MESSAGES = {

--- a/src/libs/repository.ts
+++ b/src/libs/repository.ts
@@ -21,8 +21,8 @@
 import { logger } from '@bcgov/common-nodejs-utils';
 import { Context } from 'probot';
 import config from '../config';
-import { ACCESS_CONTROL, BRANCHES, COMMIT_FILE_NAMES, COMMIT_MESSAGES, PR_TITLES, TEMPLATES, TEXT_FILES } from '../constants';
-import { addFileViaPullRequest, checkIfRefExists, extractMessage, hasPullRequestWithTitle, loadTemplate } from './utils';
+import { ACCESS_CONTROL, BRANCHES, COMMIT_MESSAGES, FILE_NAMES, PR_TITLES, TEMPLATES, TEXT_FILES } from '../constants';
+import { addFileViaPullRequest, checkIfRefExists, extractMessage, fileExists, hasPullRequestWithTitle, loadTemplate } from './utils';
 
 export const addSecurityComplianceInfoIfRequired = async (context: Context, scheduler: any = undefined) => {
 
@@ -33,13 +33,18 @@ export const addSecurityComplianceInfoIfRequired = async (context: Context, sche
   }
 
   try {
+    if ((await fileExists(context, FILE_NAMES.COMPLIANCE))) {
+      logger.info(`This repo already has a compliance file, ${context.payload.repository.name}`);
+      return;
+    }
+
     if (!(await checkIfRefExists(context, context.payload.repository.default_branch))) {
-      logger.info(`This repo has no main branch ${context.payload.repository.name}`);
+      logger.info(`This repo has no main branch, ${context.payload.repository.name}`);
       return;
     }
 
     if ((await hasPullRequestWithTitle(context, PR_TITLES.ADD_COMPLIANCE))) {
-      logger.info(`Compliance PR exists in ${context.payload.repository.name}`);
+      logger.info(`Compliance PR exists in, ${context.payload.repository.name}`);
       return;
     }
 
@@ -50,7 +55,7 @@ export const addSecurityComplianceInfoIfRequired = async (context: Context, sche
 
     await addFileViaPullRequest(context, COMMIT_MESSAGES.ADD_COMPLIANCE,
       PR_TITLES.ADD_COMPLIANCE, prMessageBody, BRANCHES.ADD_COMPLIANCE,
-      COMMIT_FILE_NAMES.COMPLIANCE, data);
+      FILE_NAMES.COMPLIANCE, data);
   } catch (err) {
     const message = extractMessage(err);
     if (message) {
@@ -86,7 +91,7 @@ export const addLicenseIfRequired = async (context: Context, scheduler: any = un
 
     await addFileViaPullRequest(context, COMMIT_MESSAGES.ADD_LICENSE,
       PR_TITLES.ADD_LICENSE, prMessageBody, BRANCHES.ADD_LICENSE,
-      COMMIT_FILE_NAMES.LICENSE, licenseData);
+      FILE_NAMES.LICENSE, licenseData);
   } catch (err) {
     const message = extractMessage(err);
     if (message) {

--- a/src/libs/robo.ts
+++ b/src/libs/robo.ts
@@ -21,7 +21,7 @@
 import { logger } from '@bcgov/common-nodejs-utils';
 import yaml from 'js-yaml';
 import { Context } from 'probot';
-import { BRANCHES, COMMENT_TRIGGER_WORD, COMMIT_FILE_NAMES, COMMIT_MESSAGES, HELP_DESK, PR_TITLES, REGEXP } from '../constants';
+import { BRANCHES, COMMENT_TRIGGER_WORD, COMMIT_MESSAGES, FILE_NAMES, HELP_DESK, PR_TITLES, REGEXP } from '../constants';
 import { assignUsersToIssue, fetchContentsForFile, updateFileContent } from './utils';
 
 /**
@@ -88,10 +88,10 @@ export const handleComplianceCommands = async (context: Context) => {
         // Fetch the file from the repo in case any updates have
         // been made to it.
         const data = await fetchContentsForFile(context,
-            COMMIT_FILE_NAMES.COMPLIANCE, BRANCHES.ADD_COMPLIANCE);
+            FILE_NAMES.COMPLIANCE, BRANCHES.ADD_COMPLIANCE);
 
         if (!data) {
-            logger.info(`Unable to fetch ${COMMIT_FILE_NAMES.COMPLIANCE} in ref ${BRANCHES.ADD_COMPLIANCE}`);
+            logger.info(`Unable to fetch ${FILE_NAMES.COMPLIANCE} in ref ${BRANCHES.ADD_COMPLIANCE}`);
             return;
         }
 
@@ -99,7 +99,7 @@ export const handleComplianceCommands = async (context: Context) => {
         doc = applyComplianceCommands(comment, doc);
 
         await updateFileContent(context, COMMIT_MESSAGES.UPDATE_COMPLIANCE,
-            BRANCHES.ADD_COMPLIANCE, COMMIT_FILE_NAMES.COMPLIANCE,
+            BRANCHES.ADD_COMPLIANCE, FILE_NAMES.COMPLIANCE,
             yaml.safeDump(doc), data.sha);
 
     } catch (err) {

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -23,7 +23,8 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import { Context } from 'probot';
 import util from 'util';
-import { REPO_COMPLIANCE_FILE, REPO_CONFIG_FILE } from '../constants';
+import { FILE_NAMES } from '../constants';
+
 interface RepoMountiePullRequestConfig {
   maxLinesChanged: number;
 }
@@ -182,7 +183,7 @@ export const fetchFile = async (
  */
 export const fetchComplianceFile = async (context: Context): Promise<RepoCompliance> => {
   try {
-    const content = await fetchFile(context, REPO_COMPLIANCE_FILE);
+    const content = await fetchFile(context, FILE_NAMES.COMPLIANCE);
     return yaml.safeLoad(content);
   } catch (err) {
     const message = 'Unable to process config file.';
@@ -200,13 +201,22 @@ export const fetchComplianceFile = async (context: Context): Promise<RepoComplia
  */
 export const fetchConfigFile = async (context: Context): Promise<RepoMountieConfig> => {
   try {
-    const content = await fetchFile(context, REPO_CONFIG_FILE);
+    const content = await fetchFile(context, FILE_NAMES.CONFIG);
     return JSON.parse(content);
   } catch (err) {
     const message = 'Unable to process config file.';
     logger.error(`${message}, error = ${err.message}`);
 
     throw new Error(message);
+  }
+};
+
+export const fileExists = async (context: Context, fileName: string): Promise<boolean> => {
+  try {
+    await fetchFile(context, fileName);
+    return true;
+  } catch (err) {
+    return false;
   }
 };
 

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -211,6 +211,14 @@ export const fetchConfigFile = async (context: Context): Promise<RepoMountieConf
   }
 };
 
+/**
+ * Determine if a file exists on the master branch
+ * The only way to check if a file exists is to attempt to fetch it;
+ * This fn is a wrapper on this capability.
+ * @param {Context} context The event context context
+ * @param {string} fileName The name of the file to lookup
+ * @returns A true if the file exists, false otherwise.
+ */
 export const fileExists = async (context: Context, fileName: string): Promise<boolean> => {
   try {
     await fetchFile(context, fileName);
@@ -403,6 +411,14 @@ export const assignUsersToIssue = async (
   }
 };
 
+/**
+ * Update the contents of a file or create it if non-existent.
+ * This fn updates the contents of a file by creating a commit
+ * with the appropriate changes.
+ * @param {Context} context The event context context
+ * @param {string} fileName The name of the file to lookup
+ * @returns undefined
+ */
 export const updateFileContent = async (
   context: Context, commitMessage: string, srcBranchName: string,
   fileName: string, fileData: string, fileSHA
@@ -425,6 +441,14 @@ export const updateFileContent = async (
   }
 };
 
+/**
+ * Check if a user is member of an organization
+ * This fn will check if the given user ID belongs to the
+ * organization in the given context.
+ * @param {Context} context The query context
+ * @param {string} userID The GitHub ID of the user
+ * @returns True if the user is a member, false otherwise
+ */
 export const isOrgMember = async (context: Context, userID: string): Promise<boolean> => {
   try {
     const response = await context.github.orgs.checkMembership({
@@ -455,6 +479,13 @@ export const isOrgMember = async (context: Context, userID: string): Promise<boo
   }
 }
 
+/**
+ * Add a comment to an issue
+ * This fn will add a comment to a given issue
+ * @param {Context} context The query context
+ * @param {string} body The comment body
+ * @returns Undefined if successful, thrown error otherwise
+ */
 export const addCommentToIssue = async (context: Context, body: string) => {
   try {
     await context.github.issues.createComment(


### PR DESCRIPTION
Currently the bot will try and create a PR to add a compliance check file even if it exists on the master branch. This PR adds the ability for the bot to check if the file exists before creating the PR.

Fixes #35 