### PR TITLE
Check if a file exists before creating a compliance PR

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -23,7 +23,7 @@ import path from 'path';
 import { Application, Context } from 'probot';
 import robot from '../src';
 import { PR_TITLES, REPO_COMPLIANCE_FILE } from '../src/constants';
-import { addCommentToIssue, addFileViaPullRequest, assignUsersToIssue, checkIfRefExists, extractMessage, fetchComplianceFile, fetchConfigFile, fetchContentsForFile, fetchFile, hasPullRequestWithTitle, isOrgMember, labelExists, loadTemplate, updateFileContent } from '../src/libs/utils';
+import { addCommentToIssue, addFileViaPullRequest, assignUsersToIssue, checkIfFileExists, checkIfRefExists, extractMessage, fetchComplianceFile, fetchConfigFile, fetchContentsForFile, fetchFile, hasPullRequestWithTitle, isOrgMember, labelExists, loadTemplate, updateFileContent } from '../src/libs/utils';
 
 jest.mock('fs');
 
@@ -268,5 +268,17 @@ describe('Utility functions', () => {
     github.issues.createComment = jest.fn().mockReturnValueOnce(Promise.reject(new Error()));
 
     await expect(addCommentToIssue(context, 'helloworld')).rejects.toThrow();
+  });
+
+  it('Return true if a file exists', async () => {
+    github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.resolve(complianceResponse));
+
+    await expect(checkIfFileExists(context, 'hello.yaml')).resolves.toBeTruthy();
+  });
+
+  it('Return false if a file does not exist', async () => {
+    github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.reject());
+
+    await expect(checkIfFileExists(context, 'hello.yaml')).resolves.toBeFalsy();
   });
 });

--- a/src/libs/repository.ts
+++ b/src/libs/repository.ts
@@ -22,7 +22,7 @@ import { logger } from '@bcgov/common-nodejs-utils';
 import { Context } from 'probot';
 import config from '../config';
 import { ACCESS_CONTROL, BRANCHES, COMMIT_FILE_NAMES, COMMIT_MESSAGES, PR_TITLES, TEMPLATES, TEXT_FILES } from '../constants';
-import { addFileViaPullRequest, checkIfRefExists, extractMessage, hasPullRequestWithTitle, loadTemplate } from './utils';
+import { addFileViaPullRequest, checkIfFileExists, checkIfRefExists, extractMessage, hasPullRequestWithTitle, loadTemplate } from './utils';
 
 export const addSecurityComplianceInfoIfRequired = async (context: Context, scheduler: any = undefined) => {
 
@@ -40,6 +40,11 @@ export const addSecurityComplianceInfoIfRequired = async (context: Context, sche
 
     if ((await hasPullRequestWithTitle(context, PR_TITLES.ADD_COMPLIANCE))) {
       logger.info(`Compliance PR exists in ${context.payload.repository.name}`);
+      return;
+    }
+
+    if ((await checkIfFileExists(context, COMMIT_FILE_NAMES.COMPLIANCE))) {
+      logger.info(`Compliance file exists in ${context.payload.repository.name}`);
       return;
     }
 

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -84,6 +84,15 @@ export const checkIfRefExists = async (context: Context, ref = context.payload.r
   }
 };
 
+export const checkIfFileExists = async (context, fileName, ref = 'master'): Promise<boolean> => {
+  try {
+    await fetchFile(context, fileName, ref);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};
+
 /**
  * Fetch the contents of a file from GitHub
  * This function will fetch the contents of a file from the latest

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -84,6 +84,15 @@ export const checkIfRefExists = async (context: Context, ref = context.payload.r
   }
 };
 
+/**
+ * Determine if a file exists on a given branch
+ * The only way to check if a file exists is to attempt to fetch it;
+ * This fn is a wrapper on this capability.
+ * @param {Context} context The event context context
+ * @param {string} fileName The name of the file to lookup
+ * @param {string} ref The name of the branch (Default: master)
+ * @returns A true if the file exists, false otherwise.
+ */
 export const checkIfFileExists = async (context, fileName, ref = 'master'): Promise<boolean> => {
   try {
     await fetchFile(context, fileName, ref);
@@ -402,6 +411,14 @@ export const assignUsersToIssue = async (
   }
 };
 
+/**
+ * Update the contents of a file or create it if non-existent.
+ * This fn updates the contents of a file by creating a commit
+ * with the appropriate changes.
+ * @param {Context} context The event context context
+ * @param {string} fileName The name of the file to lookup
+ * @returns undefined if successful, throws otherwise
+ */
 export const updateFileContent = async (
   context: Context, commitMessage: string, srcBranchName: string,
   fileName: string, fileData: string, fileSHA
@@ -424,6 +441,14 @@ export const updateFileContent = async (
   }
 };
 
+/**
+ * Check if a user is member of an organization
+ * This fn will check if the given user ID belongs to the
+ * organization in the given context.
+ * @param {Context} context The query context
+ * @param {string} userID The GitHub ID of the user
+ * @returns True if the user is a member, false otherwise
+ */
 export const isOrgMember = async (context: Context, userID: string): Promise<boolean> => {
   try {
     const response = await context.github.orgs.checkMembership({
@@ -454,6 +479,13 @@ export const isOrgMember = async (context: Context, userID: string): Promise<boo
   }
 }
 
+/**
+ * Add a comment to an issue
+ * This fn will add a comment to a given issue
+ * @param {Context} context The query context
+ * @param {string} body The comment body
+ * @returns Undefined if successful, thrown error otherwise
+ */
 export const addCommentToIssue = async (context: Context, body: string) => {
   try {
     await context.github.issues.createComment(


### PR DESCRIPTION
Currently the bot will try and create a PR to add a compliance check file even if it exists on the master branch. This PR adds the ability for the bot to check if the file exists before creating the PR.

Fixes #35