### PR TITLE
Update help command for licensing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,19 +12,28 @@
       "runtimeExecutable": null,
       "localRoot": "${workspaceFolder}/src/",
       "remoteRoot": "/opt/app-root/src/build",
-      "outFiles": ["${workspaceFolder}/build/**/*.js"],
-      "skipFiles": ["<node_internals>/**/*.js"],
+      "outFiles": [
+        "${workspaceFolder}/build/**/*.js"
+      ],
+      "skipFiles": [
+        "<node_internals>/**/*.js"
+      ],
       "sourceMaps": true
     },
     {
-      "name": "Launch Debug",​
-      "type": "node",​
-      "request": "launch",​
-      "cwd": "${workspaceRoot}",​
-      "args": ["src/main.ts"]​,
-      "runtimeArgs": ["-r", "ts-node/register"],​
+      "name": "Launch Debug",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "args": [
+        "src/main.ts"
+      ],
+      "runtimeArgs": [
+        "-r",
+        "ts-node/register"
+      ],
       "protocol": "inspector",
-      "internalConsoleOptions": "openOnSessionStart"  
+      "internalConsoleOptions": "openOnSessionStart"
     },
     {
       "name": "Attach to Process",
@@ -33,6 +42,27 @@
       "restart": true,
       "port": 5858,
       "outFiles": [],
+      "sourceMaps": true
+    },
+    {
+      "name": "Test",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/node_modules/.bin/jest",
+      "stopOnEntry": false,
+      "args": [
+        "--runInBand"
+      ],
+      "cwd": "${workspaceRoot}",
+      "preLaunchTask": null,
+      "runtimeExecutable": null,
+      "runtimeArgs": [
+        "--nolazy"
+      ],
+      "env": {
+        "NODE_ENV": "test"
+      },
+      "console": "integratedTerminal",
       "sourceMaps": true
     }
   ]

--- a/__tests__/robo.test.ts
+++ b/__tests__/robo.test.ts
@@ -72,13 +72,14 @@ describe('Bot command processing', () => {
     });
 
     it('Help requests issues are processed', async () => {
-        context.payload.comment.body = 'help';
+        context.payload.comment.body = '@repo-mountie help\n';
         const result = helpDeskSupportRequired(context.payload);
 
         expect(result).toBeTruthy();
     });
 
     it('Non-help comments are ignored', async () => {
+        context.payload.comment.body = 'I\'m a teapot';
         const result = helpDeskSupportRequired(context.payload);
 
         expect(result).toBeFalsy();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,6 +79,7 @@ export const COMMANDS = {
 export const REGEXP = {
   command: '@repo-mountie\\s+',
   compliance: '@repo-mountie\\s+update-(pia|stra)\\s+(in-progress|completed|TBD|exempt)',
+  help: '@repo-mountie\\s+help'
 }
 
 export const ACCESS_CONTROL = {

--- a/templates/why-comply.md
+++ b/templates/why-comply.md
@@ -35,7 +35,7 @@ For more information check out the [BC Policy Framework for GitHub][1].
 
 ### Pro Tip 🤓
 
-- If you're not sure what to do **add a comment below** with the command **/help** in it; a real-live-person will reply back to help you out.
+- If you're not sure what to do **add a comment below** with the command **@repo-mountie help** in it; a real-live-person will reply back to help you out.
 
 ### Commands 🤖
 


### PR DESCRIPTION
The help command for licensing was out of date and, due to some recent changes, was picking up general usage of the word help. This PR fixes the issue by making it more focused.

Fixes #51 